### PR TITLE
Fix import error with new black version

### DIFF
--- a/blue/__init__.py
+++ b/blue/__init__.py
@@ -70,7 +70,6 @@ import black.strings
 from black import Leaf, Path, click, token
 from black.cache import user_cache_dir
 from black.comments import ProtoComment, make_comment
-from black.files import tomli
 from black.linegen import LineGenerator as BlackLineGenerator
 from black.lines import Line
 from black.nodes import (
@@ -95,6 +94,10 @@ from typing import Any, Dict, Iterator, List, Optional, Pattern
 
 from click.decorators import version_option
 
+try:
+    from black.files import tomllib as tomli
+except ImportError:
+    from black.files import tomli
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
For some reason without this I get the following:
```
  File ".../.venv/lib/python3.10/site-packages/blue/__init__.py", line 76, in <module>
    from black.files import tomli
ImportError: cannot import name 'tomli' from 'black.files' (.../.venv/lib/python3.10/site-packages/black/files.py)
```

Note: The change may need reformatting